### PR TITLE
Title in event summary

### DIFF
--- a/custom_components/svitlo_live/calendar.py
+++ b/custom_components/svitlo_live/calendar.py
@@ -22,16 +22,18 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([SvitloCalendar(coordinator)])
+    title = entry.title
+    async_add_entities([SvitloCalendar(coordinator, title)])
 
 
 class SvitloCalendar(CoordinatorEntity, CalendarEntity):
     """Календар відключень світла для конкретного регіону/черги."""
 
-    def __init__(self, coordinator) -> None:
+    def __init__(self, coordinator, title) -> None:
         super().__init__(coordinator)
         self._attr_unique_id = f"svitlo_calendar_{coordinator.region}_{coordinator.queue}"
         self._attr_name = f"Svitlo • {coordinator.region} / {coordinator.queue}"
+        self.summary = f"❌ {title}: Power outage"
         self._event: Optional[CalendarEvent] = None
 
     # ---- обов'язково для стану календаря ----
@@ -146,7 +148,7 @@ class SvitloCalendar(CoordinatorEntity, CalendarEntity):
 
        
         return CalendarEvent(
-            summary="❌ Power outage ❌",
+            summary=self.summary,
             start=start_utc,
             end=end_utc,
             description=f"No electricity {start_local.strftime('%H:%M')}–{end_local.strftime('%H:%M')}",


### PR DESCRIPTION
The goal is to add the title name to the calendar event. 
If you use more than one integration, it's not easy to see which record corresponds to which location.
<img width="511" height="387" alt="image" src="https://github.com/user-attachments/assets/09398231-64ec-4884-b8d1-cd8efcf53267" />
It would be better to have different event summary for each location:
```
❌ Home: Power outage
❌ Work: Power outage
❌ Parents: Power outage
```
**I don't know if it is going to work, and I don't know how to test it.**