### PR TITLE
Fixed issues with svitlo_schedule_updated_notification.yaml

### DIFF
--- a/custom_components/svitlo_live/blueprints/automation/svitlo_schedule_updated_notification.yaml
+++ b/custom_components/svitlo_live/blueprints/automation/svitlo_schedule_updated_notification.yaml
@@ -102,9 +102,6 @@ action:
         value_template: "{{ changed }}"
     then:
       - variables:
-          today_iso: "{{ now().astimezone(now().tzinfo).date().isoformat() }}"
-          tomorrow_iso: "{{ (now().astimezone(now().tzinfo) + timedelta(days=1)).date().isoformat() }}"
-
           events_today: >-
             {% set today = now().astimezone(now().tzinfo).date() %}
             {% set ns = namespace(events=[]) %}


### PR DESCRIPTION
### Detected the issue with template after changes.
Outages according to UTC with the current day date were shown as today outages even acording to Kyiv TZ they are tommorow.

Before changes
<img width="337" height="247" alt="image" src="https://github.com/user-attachments/assets/3511a255-0854-467d-880f-37c53119b421" />


After changes
<img width="368" height="257" alt="image" src="https://github.com/user-attachments/assets/3eacf1b3-5894-4969-a8e2-b870f595626b" />

    events:
      - start: '2025-11-12T00:30:00+00:00'
        end: '2025-11-12T04:30:00+00:00'
        summary: '[Київ 2.1] ❌ Відключення електроенергії'
        description: '[Київ 2.1] Немає світла 02:30–06:30'
      - start: '2025-11-12T11:00:00+00:00'
        end: '2025-11-12T15:00:00+00:00'
        summary: '[Київ 2.1] ❌ Відключення електроенергії'
        description: '[Київ 2.1] Немає світла 13:00–17:00'
      - start: '2025-11-12T21:30:00+00:00'
        end: '2025-11-12T22:00:00+00:00'
        summary: '[Київ 2.1] ❌ Відключення електроенергії'
        description: '[Київ 2.1] Немає світла 23:30–00:00'
      - start: '2025-11-12T22:00:00+00:00'
        end: '2025-11-13T01:30:00+00:00'
        summary: '[Київ 2.1] ❌ Відключення електроенергії'
        description: '[Київ 2.1] Немає світла 00:00–03:30'
      - start: '2025-11-13T08:00:00+00:00'
        end: '2025-11-13T12:00:00+00:00'
        summary: '[Київ 2.1] ❌ Відключення електроенергії'
        description: '[Київ 2.1] Немає світла 10:00–14:00'
      - start: '2025-11-13T18:30:00+00:00'
        end: '2025-11-13T22:00:00+00:00'
        summary: '[Київ 2.1] ❌ Відключення електроенергії'
        description: '[Київ 2.1] Немає світла 20:30–00:00'

### Additionaly changed:
-  truncation from :255 to -255: to cut the beginning of the string and truncation to comparison is_changed as well to avoid comparing truncated and not truncated string and getting not the same for same string. Often the end of the srting will be different (next day outages) that is the reason i think it's better to truncate beginning instead of the end.

- addd location name string to use it instead of using key of outage queue

