### PR TITLE
Ensure Vinnytsia queue selector shows split numbering

### DIFF
--- a/custom_components/svitlo_live/config_flow.py
+++ b/custom_components/svitlo_live/config_flow.py
@@ -14,6 +14,12 @@ REGION_UI_LIST: List[str] = list(REGION_SLUG_TO_UI.values())
 REGION_UI_OPTIONS = [{"label": name, "value": name} for name in REGION_UI_LIST]
 
 def _queue_options_for_region(region_slug: str) -> Tuple[List[str], List[Dict[str, str]], str]:
+    if region_slug == "vinnitska-oblast":
+        values = [f"{i}.{j}" for i in range(1, 7) for j in (1, 2)]
+        default = "1.1"
+        options = [{"label": v, "value": v} for v in values]
+        return values, options, default
+
     mode = REGION_QUEUE_MODE.get(region_slug, "DEFAULT")
     if mode == "CHERGA_NUM":
         values = [str(i) for i in range(1, 7)]

--- a/custom_components/svitlo_live/const.py
+++ b/custom_components/svitlo_live/const.py
@@ -44,7 +44,6 @@ REGIONS = {
 
 # Мапа режимів вибору черги/групи
 REGION_QUEUE_MODE = {
-    "vinnitska-oblast": "CHERGA_NUM",
     "chernivetska-oblast": "GRUPA_NUM",
     "donetska-oblast": "GRUPA_NUM",
 }


### PR DESCRIPTION
## Summary
- force Vinnytska oblast to use the split queue numbering (1.1–6.2) in the config flow so the UI offers the correct options

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a55b2aaf4832382dd411093eb0d77)