### PR TITLE
Update const.py

### DIFF
--- a/custom_components/svitlo_live/const.py
+++ b/custom_components/svitlo_live/const.py
@@ -44,7 +44,6 @@ REGIONS = {
 
 # Мапа режимів вибору черги/групи
 REGION_QUEUE_MODE = {
-    "vinnitska-oblast": "CHERGA_NUM",
     "chernivetska-oblast": "GRUPA_NUM",
     "donetska-oblast": "GRUPA_NUM",
 }


### PR DESCRIPTION
## Summary
- force Vinnytska oblast to use the split queue numbering (1.1–6.2) in the config flow so the UI offers the correct options
