### PR TITLE
Fix Telegram parse_mode casing for HA 2026.2+ (HTML -> html)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.DS_Store

--- a/custom_components/svitlo_live/blueprints/automation/svitlo_schedule_updated_notification.yaml
+++ b/custom_components/svitlo_live/blueprints/automation/svitlo_schedule_updated_notification.yaml
@@ -346,7 +346,7 @@ action:
                         {% endif %}
                       title: "{{ final_title }}"
                       message: "{{ body_text }}"
-                      parse_mode: HTML
+                      parse_mode: html
             # Старий bot (без config_entry_id)
             default:
               - service: telegram_bot.send_message
@@ -359,7 +359,7 @@ action:
                     {% endif %}
                   title: "{{ final_title }}"
                   message: "{{ body_text }}"
-                  parse_mode: HTML
+                  parse_mode: html
 
       # 2.3) Persistent Notification
       - if:


### PR DESCRIPTION
### What was fixed
Home Assistant 2026.2+ validates `parse_mode` strictly and accepts only:
`html`, `markdown`, `markdownv2`, `plain_text`.

Blueprint was using `HTML`, which causes:
value must be one of [‘html’, ‘markdown’, ‘markdownv2’, ‘plain_text’]

### Changes
- Replaced `parse_mode: HTML` with `parse_mode: html` in Telegram notification actions lines: 349, 362

### Result
Telegram notifications work again on HA 2026.2+

Thanks for the great integration 🙌